### PR TITLE
Correct jobDslTest task name

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,7 +5,7 @@
 - Fix: Used wrong version of test support lib
 
 = 2.0.0 (2017-05-11)
-- Removed `run`, `runAll` tasks and renamed `testDsl` to `jobDslTests`
+- Removed `run`, `runAll` tasks and renamed `testDsl` to `jobDslTest`
 - Changed test execution mechanism to use a Jenkins test harness
 - Support most recent Job DSL version (1.63)
 - Publish plugin to Gradle Plugin Portal

--- a/README.adoc
+++ b/README.adoc
@@ -123,7 +123,7 @@ in Jenkins (e.g. `lib/*.jar`) - see below.
 
 * `gradlew build` - Compile code in `src/main/groovy`, execute (job-dsl) tests and copy
   compile dependencies into `lib` folder (calls `libs` task)
-* `gradlew jobDslTests` - Executes all DSL scripts to ensure no error. If everything
+* `gradlew jobDslTest` - Executes all DSL scripts to ensure no error. If everything
   is fine Gradle will say `BUILD SUCCESSFUL`. Otherwise open the test report
   from `build/reports/test/index.html`.
   The generated config xml files are located in `build/debug-xml/<jobs|views>` for inspection


### PR DESCRIPTION
Task name doesn't have a `s` suffix:

    Task 'jobDslTests' not found in root project 'jenkins-dsl'. Some candidates are: 'jobDslTest'