### PR TITLE
[Feature] Adds filename check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .gradle
 build
 target
+out
 
 .idea
 *.iml

--- a/jenkins-job-dsl-gradle-plugin/src/test/groovy/com/aoe/gradle/jenkinsjobdsl/IncorrectFilenameSpec.groovy
+++ b/jenkins-job-dsl-gradle-plugin/src/test/groovy/com/aoe/gradle/jenkinsjobdsl/IncorrectFilenameSpec.groovy
@@ -6,7 +6,7 @@ import static org.gradle.testkit.runner.TaskOutcome.FAILED
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
 /**
- * @author Carsten Lenz, AOE
+ * @author Tomas Norre Mikkelsen
  */
 class IncorrectFilenameSpec extends AbstractGradleProjectSpec {
 

--- a/jenkins-job-dsl-gradle-plugin/src/test/groovy/com/aoe/gradle/jenkinsjobdsl/IncorrectFilenameSpec.groovy
+++ b/jenkins-job-dsl-gradle-plugin/src/test/groovy/com/aoe/gradle/jenkinsjobdsl/IncorrectFilenameSpec.groovy
@@ -1,0 +1,61 @@
+package com.aoe.gradle.jenkinsjobdsl
+
+import org.gradle.testkit.runner.GradleRunner
+
+import static org.gradle.testkit.runner.TaskOutcome.FAILED
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+/**
+ * @author Carsten Lenz, AOE
+ */
+class IncorrectFilenameSpec extends AbstractGradleProjectSpec {
+
+    def setup() {
+        def sample = new File(jobsDir, '1sample.groovy')
+        sample << """
+
+job("1-job-with-digit") {
+    
+}
+"""
+        buildFile << """
+        plugins {
+            id 'com.aoe.jenkins-job-dsl'
+        }
+
+        repositories {
+            mavenLocal()
+        }
+        
+        dependencies {
+            jenkinsPlugin 'org.jenkins-ci.plugins:ghprb:1.31.4'
+            jenkinsPlugin 'com.coravy.hudson.plugins.github:github:1.19.0'
+            jenkinsPlugin 'org.jenkins-ci.plugins:cloudbees-folder:5.0'
+        }
+
+        jobDsl {
+            sourceDir 'src/jobs'
+        }
+        
+        jobDslTest {
+            doFirst {
+              classpath.each {
+                println "\${it.path}"
+              }
+            }
+         }
+        """.stripIndent()
+    }
+
+    def "executing jobDslTest"() {
+        when:
+        def result = GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments('jobDslTest')
+                .withPluginClasspath()
+                .buildAndFail()
+
+        then:
+        result.task(':jobDslTest').outcome == FAILED
+    }
+}

--- a/jenkins-job-dsl-test-support/build.gradle
+++ b/jenkins-job-dsl-test-support/build.gradle
@@ -9,6 +9,8 @@ dependencies {
     compile "org.jenkins-ci.main:jenkins-war:${versions.jenkins}"
     compile "org.jenkins-ci.main:jenkins-war:${versions.jenkins}:war-for-test@jar"
 
+    compile 'commons-io:commons-io:2.4'
+
     // needed optional dependency of of jenkins-core
     compile 'javax.servlet:servlet-api:2.4'
 }

--- a/jenkins-job-dsl-test-support/src/test/groovy/com/aoe/gradle/jenkinsjobdsl/DslTestSupportSpec.groovy
+++ b/jenkins-job-dsl-test-support/src/test/groovy/com/aoe/gradle/jenkinsjobdsl/DslTestSupportSpec.groovy
@@ -1,7 +1,0 @@
-package com.aoe.gradle.jenkinsjobdsl
-
-/**
- * @author Carsten Lenz, AOE
- */
-class DslTestSupportSpec extends JobScriptsSpec {
-}

--- a/jenkins-job-dsl-test-support/src/test/groovy/com/aoe/gradle/jenkinsjobdsl/JobScriptsSpecTest.groovy
+++ b/jenkins-job-dsl-test-support/src/test/groovy/com/aoe/gradle/jenkinsjobdsl/JobScriptsSpecTest.groovy
@@ -1,0 +1,34 @@
+package com.aoe.gradle.jenkinsjobdsl
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * @author Carsten Lenz, AOE
+ */
+class JobScriptsSpecTest extends Specification {
+
+    @Unroll
+    void 'test isValidScriptName'() {
+        given:
+        def exceptionThrown = false
+
+        when:
+        try {
+            JobScriptsSpec.assertValidFilename(filename)
+        } catch (AssertionError e) {
+            exceptionThrown = true
+        }
+
+        then:
+        shouldThrowException == exceptionThrown
+
+        where:
+        filename                                         | shouldThrowException
+        new File('/path/to/1digit-start.groovy')         | true
+        new File('/path/to/with-hyphen.groovy')          | true
+        new File('acceptedNameWithoutPath.groovy')       | false
+        new File('/path/to/acceptedNameWithPath.groovy') | false
+    }
+
+}


### PR DESCRIPTION
This will adds filename check to the JobDSLTest Gradle Task.

It is conform with the Java Identifier conventions which is used by the JobDSL Plugin in Jenkins already.