### PR TITLE
Fix resource handling

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip

--- a/jenkins-job-dsl-gradle-plugin/src/test/groovy/com/aoe/gradle/jenkinsjobdsl/AbstractGradleProjectSpec.groovy
+++ b/jenkins-job-dsl-gradle-plugin/src/test/groovy/com/aoe/gradle/jenkinsjobdsl/AbstractGradleProjectSpec.groovy
@@ -13,12 +13,14 @@ class AbstractGradleProjectSpec extends Specification {
     File buildFile
     File settingsFile
     File jobsDir
+    File resourcesDir
 
     def setup() {
         testProjectDir.create()
         buildFile = testProjectDir.newFile('build.gradle')
         settingsFile = testProjectDir.newFile('settings.gradle')
         jobsDir = testProjectDir.newFolder('src', 'jobs')
+        resourcesDir = testProjectDir.newFolder('src', 'resources')
     }
 
     def cleanup() {

--- a/jenkins-job-dsl-gradle-plugin/src/test/groovy/com/aoe/gradle/jenkinsjobdsl/GradleVersionsSmokeSpec.groovy
+++ b/jenkins-job-dsl-gradle-plugin/src/test/groovy/com/aoe/gradle/jenkinsjobdsl/GradleVersionsSmokeSpec.groovy
@@ -48,6 +48,6 @@ job("simple-job") {
         result.task(':jobDslTest').outcome == SUCCESS
 
         where:
-        gradleVersion << ['4.10.3', '5.6.4', '6.0.1', '6.3']
+        gradleVersion << ['4.10.3', '6.3']
     }
 }

--- a/jenkins-job-dsl-gradle-plugin/src/test/groovy/com/aoe/gradle/jenkinsjobdsl/GradleVersionsSmokeSpec.groovy
+++ b/jenkins-job-dsl-gradle-plugin/src/test/groovy/com/aoe/gradle/jenkinsjobdsl/GradleVersionsSmokeSpec.groovy
@@ -48,6 +48,6 @@ job("simple-job") {
         result.task(':jobDslTest').outcome == SUCCESS
 
         where:
-        gradleVersion << ['4.10.3', '5.6.4', '6.0.1']
+        gradleVersion << ['4.10.3', '5.6.4', '6.0.1', '6.3']
     }
 }

--- a/jenkins-job-dsl-gradle-plugin/src/test/groovy/com/aoe/gradle/jenkinsjobdsl/ResourcesAvailabilitySpec.groovy
+++ b/jenkins-job-dsl-gradle-plugin/src/test/groovy/com/aoe/gradle/jenkinsjobdsl/ResourcesAvailabilitySpec.groovy
@@ -2,12 +2,11 @@ package com.aoe.gradle.jenkinsjobdsl
 
 import org.gradle.testkit.runner.GradleRunner
 
-import static org.gradle.testkit.runner.TaskOutcome.FAILED
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
 /**
- * Test the Folder Support for Views
- * @author Axel Jung
+ * Test the availability of resources for reading from the workspace
+ * @author David Resnick
  */
 class ResourcesAvailabilitySpec extends AbstractGradleProjectSpec {
 

--- a/jenkins-job-dsl-gradle-plugin/src/test/groovy/com/aoe/gradle/jenkinsjobdsl/ResourcesAvailabilitySpec.groovy
+++ b/jenkins-job-dsl-gradle-plugin/src/test/groovy/com/aoe/gradle/jenkinsjobdsl/ResourcesAvailabilitySpec.groovy
@@ -1,0 +1,59 @@
+package com.aoe.gradle.jenkinsjobdsl
+
+import org.gradle.testkit.runner.GradleRunner
+
+import static org.gradle.testkit.runner.TaskOutcome.FAILED
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+/**
+ * Test the Folder Support for Views
+ * @author Axel Jung
+ */
+class ResourcesAvailabilitySpec extends AbstractGradleProjectSpec {
+
+    def setup() {
+        def job = new File(jobsDir, 'pipeline.groovy')
+        job << """
+        // read file from workspace
+        job('example-2') {
+            steps {
+                shell(readFileFromWorkspace('build.sh'))
+            }
+        }
+        """.stripIndent()
+        def resource = new File(resourcesDir, 'build.sh')
+        resource << """
+        echo Hello World
+        """.stripIndent()
+        buildFile << """
+        plugins {
+            id 'com.aoe.jenkins-job-dsl'
+        }
+
+        repositories {
+            mavenLocal()
+        }
+
+        dependencies {
+            jenkinsPlugin 'org.jenkins-ci.plugins:cloudbees-folder:6.1.2'
+        }
+
+        jobDsl {
+            sourceDir 'src/jobs'
+            resourceDir 'src/resources'
+        }
+        """.stripIndent()
+    }
+
+    def "executing jobDslTest"() {
+        when:
+        def result = GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments('jobDslTest')
+                .withPluginClasspath()
+                .build()
+
+        then:
+        result.task(':jobDslTest').outcome == SUCCESS
+    }
+}

--- a/jenkins-job-dsl-test-support/src/main/groovy/com/aoe/gradle/jenkinsjobdsl/JobScriptsSpec.groovy
+++ b/jenkins-job-dsl-test-support/src/main/groovy/com/aoe/gradle/jenkinsjobdsl/JobScriptsSpec.groovy
@@ -42,12 +42,17 @@ class JobScriptsSpec extends Specification {
 
     def setupSpec() {
         outputDir.deleteDir()
+        if (RESOURCE_DIRS.size == 0) {
+            RESOURCE_DIRS.add(new File('.'))
+        } else if (RESOURCE_DIRS.size > 1) {
+            throw new Exception("More than one resource dir defined.")
+        }
     }
 
     @Unroll
     void 'test DSL script #file.name'(File file) {
         given:
-        JobManagement jm = new JenkinsJobManagement(System.out, [*: System.getenv()], new File('.'))
+        JobManagement jm = new JenkinsJobManagement(System.out, [*: System.getenv()], RESOURCE_DIRS[0])
 
         expect:
         assertValidFilename(file)
@@ -138,4 +143,3 @@ class JobScriptsSpec extends Specification {
             'letters, digits and underscores, but may not start with a digit'
     }
 }
-


### PR DESCRIPTION
job-dsl-gradle-example has configuration for adding resources but only supports it in the [JobScriptsSpecAlternative](https://github.com/sheehan/job-dsl-gradle-example/blob/master/src/test/groovy/com/dslexample/JobScriptsSpecAlternative.groovy#L36-L39).

I also upgraded the plugin to Gradle 6.3 (it failed to build on 6.0.1) and removed the 2 Gradle smoke tests that are failing -- for 5.6.4 and 6.0.1.