### PR TITLE
Remove the gradle version println call

### DIFF
--- a/jenkins-job-dsl-gradle-plugin/src/main/groovy/com/aoe/gradle/jenkinsjobdsl/JobDslPlugin.groovy
+++ b/jenkins-job-dsl-gradle-plugin/src/main/groovy/com/aoe/gradle/jenkinsjobdsl/JobDslPlugin.groovy
@@ -203,7 +203,6 @@ class JobDslPlugin implements Plugin<Project> {
     }
 
     boolean isGradleFiveOrGreater(Project project) {
-        println(project.gradle.gradleVersion)
         VersionNumber.parse(project.gradle.gradleVersion) >= VersionNumber.parse("5.0.0")
     }
 }


### PR DESCRIPTION
# TL;DR 
This call was _always_ printing to the console. Nothing more than a minor annoyance IMHO.

Seems to me that it was left over from an experiment? As the method is used to determine the testClassesDirs vs testClassesDir..