### PR TITLE
Use HTTPS for jenkins maven repository

### DIFF
--- a/jenkins-job-dsl-gradle-plugin/src/main/groovy/com/aoe/gradle/jenkinsjobdsl/JobDslPlugin.groovy
+++ b/jenkins-job-dsl-gradle-plugin/src/main/groovy/com/aoe/gradle/jenkinsjobdsl/JobDslPlugin.groovy
@@ -67,7 +67,7 @@ class JobDslPlugin implements Plugin<Project> {
 
             if (extension.addRepositories) {
                 proj.repositories {
-                    maven { url 'http://repo.jenkins-ci.org/public' }
+                    maven { url 'https://repo.jenkins-ci.org/public' }
                     jcenter()
                 }
             }


### PR DESCRIPTION
We started getting `Could not parse POM ... The element type "hr" must
be terminated ..."` errors today.

Changing the jenkins maven repository URL to use https solves the issue.
