### PR TITLE
Update Jenkins repository URL within `build.gradle`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ subprojects {
     apply from: "${rootDir}/gradle/bintrayUpload.gradle"
 
     repositories {
-        maven { url 'http://repo.jenkins-ci.org/public' }
+        maven { url 'https://repo.jenkins-ci.org/public' }
         jcenter()
     }
 


### PR DESCRIPTION
Hi there,

following up on #24, this patch also updates the repository URL to use `https` within the `build.gradle` file.

With kind regards,
Andreas.
