### PR TITLE
Update JobDslPlugin.groovy for Gradle 7+support

### DIFF
--- a/jenkins-job-dsl-gradle-plugin/src/main/groovy/com/aoe/gradle/jenkinsjobdsl/JobDslPlugin.groovy
+++ b/jenkins-job-dsl-gradle-plugin/src/main/groovy/com/aoe/gradle/jenkinsjobdsl/JobDslPlugin.groovy
@@ -187,7 +187,7 @@ class JobDslPlugin implements Plugin<Project> {
     void addDependenciesManifestationTasks(Project project) {
         Task libs = project.task('libs', type: Copy) {
             description = 'Copies all compile dependencies into a local folder (\'lib\' by default)'
-            from(project.configurations.compile - project.configurations.provided)
+            from(project.configurations.implementation - project.configurations.provided)
             into 'lib'
         }
 


### PR DESCRIPTION
The compile configuration has been deprecated and must be replaced with implementation